### PR TITLE
[2/2] Fix MIRR function: use fv_internal to avoid Excel sign convention

### DIFF
--- a/src/rate/mirr.rs
+++ b/src/rate/mirr.rs
@@ -1,5 +1,5 @@
 use crate::rate::cagr;
-use crate::tvm::{fv, pv};
+use crate::tvm::{fv_internal, pv};
 use crate::ZERO;
 use rust_decimal::prelude::*;
 use rust_decimal_macros::*;
@@ -44,7 +44,7 @@ pub fn mirr(cash_flows: &[Decimal], finance_rate: Decimal, reinvest_rate: Decima
             npv_neg += pv(finance_rate, i.into(), ZERO, Some(cf), None);
         } else {
             // Calculate the future value of positive cash flows
-            fv_pos += fv(reinvest_rate, (n - i).into(), ZERO, Some(cf), None);
+            fv_pos += fv_internal(reinvest_rate, (n - i).into(), ZERO, Some(cf), None);
         }
     }
     npv_neg.set_sign_positive(true);
@@ -112,7 +112,7 @@ pub fn xmirr(flow_table: &[(Decimal, i32)], finance_rate: Decimal, reinvest_rate
                 None,
             );
         } else {
-            fv_pos += fv(
+            fv_pos += fv_internal(
                 reinvest_rate,
                 (n - Decimal::from_i32(date).unwrap()) / dec!(365),
                 ZERO,

--- a/src/tvm/fv.rs
+++ b/src/tvm/fv.rs
@@ -35,7 +35,7 @@ use rust_decimal::prelude::*;
 /// fv(rate, nper, pmt, None, None);
 /// ```
 /// Internal FV calculation with mathematically correct signs
-fn fv_internal(rate: Decimal, nper: Decimal, pmt: Decimal, pv: Option<Decimal>, due: Option<bool>) -> Decimal {
+pub fn fv_internal(rate: Decimal, nper: Decimal, pmt: Decimal, pv: Option<Decimal>, due: Option<bool>) -> Decimal {
     let pv = pv.unwrap_or(ZERO);
     let due = due.unwrap_or(false);
 

--- a/src/tvm/mod.rs
+++ b/src/tvm/mod.rs
@@ -7,7 +7,7 @@
 
 // FV - Future Value
 mod fv;
-pub use fv::fv;
+pub use fv::{fv, fv_internal};
 
 // PV - Present Value
 mod pv;


### PR DESCRIPTION
**Stack:**

* https://github.com/nobie-org/rust-finprim/pull/1
* https://github.com/nobie-org/rust-finprim/pull/2


---

Fix MIRR function: use fv_internal to avoid Excel sign convention

- MIRR function was using the Excel-compatible fv() which negates results
- Changed to use fv_internal() for mathematically correct calculations
- Updated XMIRR function as well
- Made fv_internal() public and exported from tvm module

